### PR TITLE
Use path prefix

### DIFF
--- a/backends/apisvr/cmd/server/dump.go
+++ b/backends/apisvr/cmd/server/dump.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+func withRequestDumping(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dump, err := httputil.DumpRequest(r, true)
+		if err != nil {
+			log.Printf("Error dumping request: %v", err)
+		} else {
+			log.Printf("Request: %s", dump)
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backends/apisvr/cmd/server/main.go
+++ b/backends/apisvr/cmd/server/main.go
@@ -43,12 +43,12 @@ func main() {
 
 	// https://connectrpc.com/docs/go/deployment/
 	// https://github.com/connectrpc/examples-go/blob/main/cmd/demoserver/main.go
+	muxHandler := withCORS(h2c.NewHandler(mux, &http2.Server{}))
+	muxHandler = withRequestDumping(muxHandler)
+
 	srv := &http.Server{
-		Addr: serverHostAndPort,
-		Handler: h2c.NewHandler(
-			withCORS(h2c.NewHandler(mux, &http2.Server{})),
-			&http2.Server{},
-		),
+		Addr:              serverHostAndPort,
+		Handler:           h2c.NewHandler(muxHandler, &http2.Server{}),
 		ReadHeaderTimeout: time.Second,
 		ReadTimeout:       5 * time.Minute,
 		WriteTimeout:      5 * time.Minute,

--- a/backends/apisvr/cmd/server/main.go
+++ b/backends/apisvr/cmd/server/main.go
@@ -19,6 +19,8 @@ import (
 	taskservices "apisvr/services/task_services"
 )
 
+const pathPrefix = "/api"
+
 func main() {
 	mux := http.NewServeMux()
 
@@ -27,7 +29,7 @@ func main() {
 
 	taskService := &taskservices.TaskService{}
 	path, handler := taskv1connect.NewTaskServiceHandler(taskService)
-	mux.Handle(path, authmw.Wrap(handler))
+	mux.Handle(pathPrefix+path, authmw.Wrap(http.StripPrefix(pathPrefix, handler)))
 
 	// https://cloud.google.com/run/docs/triggering/grpc?hl=ja
 	serverHostAndPort := os.Getenv("APP_SERVER_HOST_AND_PORT")

--- a/frontends/uisvr/package-lock.json
+++ b/frontends/uisvr/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@bufbuild/protobuf": "^1.8.0",
 				"@connectrpc/connect": "^1.4.0",
+				"@connectrpc/connect-node": "^1.4.0",
 				"@connectrpc/connect-web": "^1.4.0",
 				"dotenv": "^16.4.5",
 				"firebase": "^10.11.0",
@@ -259,6 +260,21 @@
 			"integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
 			"peerDependencies": {
 				"@bufbuild/protobuf": "^1.4.2"
+			}
+		},
+		"node_modules/@connectrpc/connect-node": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.4.0.tgz",
+			"integrity": "sha512-0ANnrr6SvsjevsWEgdzHy7BaHkluZyS6s4xNoVt7RBHFR5V/kT9lPokoIbYUOU9JHzdRgTaS3x5595mwUsu15g==",
+			"dependencies": {
+				"undici": "^5.28.3"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.4.2",
+				"@connectrpc/connect": "1.4.0"
 			}
 		},
 		"node_modules/@connectrpc/connect-web": {

--- a/frontends/uisvr/package.json
+++ b/frontends/uisvr/package.json
@@ -52,6 +52,7 @@
 	"dependencies": {
 		"@bufbuild/protobuf": "^1.8.0",
 		"@connectrpc/connect": "^1.4.0",
+		"@connectrpc/connect-node": "^1.4.0",
 		"@connectrpc/connect-web": "^1.4.0",
 		"dotenv": "^16.4.5",
 		"firebase": "^10.11.0",

--- a/frontends/uisvr/src/routes/+page.server.ts
+++ b/frontends/uisvr/src/routes/+page.server.ts
@@ -15,7 +15,7 @@ export async function load(event: ServerLoadEvent): Promise<{ tasks: Task[] }> {
 	console.log('load: event.constructor', event.constructor);
 
 	const transport = createConnectTransport({
-		baseUrl: apisvrOrigin,
+		baseUrl: apisvrOrigin + '/api',
 		interceptors: [
 			(next) => async (req) => {
 				req.header.set('cookie', event.request.headers.get('cookie') || '');

--- a/frontends/uisvr/src/routes/+page.server.ts
+++ b/frontends/uisvr/src/routes/+page.server.ts
@@ -3,7 +3,7 @@ import type { ServerLoadEvent } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { TaskService } from '../gen/task/v1/task_connect';
 import { createPromiseClient } from '@connectrpc/connect';
-import { createConnectTransport } from '@connectrpc/connect-web';
+import { createConnectTransport } from '@connectrpc/connect-node'; // NOT from '@connectrpc/connect-web';
 import { Status } from '../gen/task/v1/task_pb';
 import { apisvrOrigin } from '$lib/server/apisvr';
 
@@ -15,6 +15,7 @@ export async function load(event: ServerLoadEvent): Promise<{ tasks: Task[] }> {
 	console.log('load: event.constructor', event.constructor);
 
 	const transport = createConnectTransport({
+		httpVersion: '2',
 		baseUrl: apisvrOrigin + '/api',
 		interceptors: [
 			(next) => async (req) => {

--- a/frontends/uisvr/src/routes/+page.svelte
+++ b/frontends/uisvr/src/routes/+page.svelte
@@ -9,10 +9,10 @@
 
 	export let data: { tasks: Task[] };
 
-	const transport = createConnectTransport({ 
-		baseUrl: apisvrOrigin,
+	const transport = createConnectTransport({
+		baseUrl: apisvrOrigin + '/api',
 		credentials: 'include'
-	 });
+	});
 	const client = createPromiseClient(TaskService, transport);
 </script>
 
@@ -46,7 +46,11 @@
 						checked={task.done}
 						on:change={async (e) => {
 							const done = e.currentTarget.checked;
-							await client.update({ id: task.id, name: task.name, status: done ? Status.DONE : Status.TODO });
+							await client.update({
+								id: task.id,
+								name: task.name,
+								status: done ? Status.DONE : Status.TODO
+							});
 						}}
 					/>
 					<span>{task.name}</span>
@@ -55,8 +59,8 @@
 						on:click={async (e) => {
 							await client.delete({ id: task.id });
 							data.tasks = data.tasks.filter((t) => t !== task);
-						}}
-					><Icon icon="ph:trash-light" /></button>
+						}}><Icon icon="ph:trash-light" /></button
+					>
 				</label>
 			</li>
 		{/each}


### PR DESCRIPTION
- Use path prefix `/api` 
    - Use [http.StripPrefix](https://pkg.go.dev/net/http#StripPrefix) in apisvr
    - Add `/api` to baseUrl of Transport
- [Use @connectrpc/connect-node instead of @connectrpc/connect-web to call API from uisvr server-side](https://github.com/akm/govelte-todo/commit/494b219be282592c14585550a2745725ac02b488) 
- [Use httputil.DumpRequest for debug](https://github.com/akm/govelte-todo/commit/49d7ae3d78905292dacc5ae64264f35bede4698a)